### PR TITLE
chore: update maven dependency to use hytale maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,16 @@
             <id>squiddev</id>
             <url>https://squiddev.cc/maven/</url>
         </repository>
+        <!-- Hytale release repository -->
+        <repository>
+            <id>hytale-release</id>
+            <url>https://maven.hytale.com/release</url>
+        </repository>
+        <!-- Hytale pre-release repository -->
+        <repository>
+            <id>hytale-pre-release</id>
+            <url>https://maven.hytale.com/pre-release</url>
+        </repository>
     </repositories>
 
     <build>
@@ -67,10 +77,9 @@
     <dependencies>
         <dependency>
             <groupId>com.hypixel.hytale</groupId>
-            <artifactId>HytaleServer-parent</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/libs/HytaleServer.jar</systemPath>
+            <artifactId>Server</artifactId>
+            <version>2026.01.22-6f8bdbdc4</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Add Hytale maven repository and dependency instead of a local file now that it is available : 

```xml
    <repositories>
        <repository>
            <id>squiddev</id>
            <url>https://squiddev.cc/maven/</url>
        </repository>
        <!-- Hytale release repository -->
        <repository>
            <id>hytale-release</id>
            <url>https://maven.hytale.com/release</url>
        </repository>
        <!-- Hytale pre-release repository -->
        <repository>
            <id>hytale-pre-release</id>
            <url>https://maven.hytale.com/pre-release</url>
        </repository>
    </repositories>
```

```xml
        <dependency>
            <groupId>com.hypixel.hytale</groupId>
            <artifactId>Server</artifactId>
            <version>2026.01.22-6f8bdbdc4</version>
            <scope>provided</scope>
        </dependency>
```