### PR TITLE
Added `Hytale:BlockModule` as a hard dependency

### DIFF
--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -11,7 +11,9 @@
   ],
   "Website": "https://github.com/cozyGalvinism/HyCompute",
   "ServerVersion": "*",
-  "Dependencies": {},
+  "Dependencies": {
+    "Hytale:BlockModule": "*"
+  },
   "OptionalDependencies": {},
   "DisabledByDefault": false,
   "IncludesAssetPack": true


### PR DESCRIPTION
This fixes an intermittent issue where the `Hytale:BlockModule` would load after `HyCompute:HyCompute` causing a crash due to `BlockStateInfo`'s Component Type being non-existent